### PR TITLE
Release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.9](https://github.com/elkowar/yolk/compare/v0.0.8...v0.0.9) - 2024-12-09
+
+### Added
+
+- add replace_number tag function
+
+### Fixed
+
+- show source in errors in yolk.lua
+- parser not preserving newline after conditional end tag
+
+### Other
+
+- disable dependency updates in release-plz config

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,7 +1589,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "assert_fs",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/script/stdlib.rs
+++ b/src/script/stdlib.rs
@@ -40,6 +40,7 @@ pub fn setup_stdlib(eval_mode: EvalMode, eval_ctx: &EvalCtx) -> Result<(), LuaEr
     )?;
     // TODO: Add regex capture group functions
     // TODO: Add to_json and from_json functions
+    // TODO: add table_contains and list_contains functions
     Ok(())
 }
 


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.8 -> 0.0.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/elkowar/yolk/compare/v0.0.8...v0.0.9) - 2024-12-09

### Added

- add replace_number tag function

### Fixed

- show source in errors in yolk.lua
- parser not preserving newline after conditional end tag

### Other

- disable dependency updates in release-plz config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).