### PR TITLE
Release v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/elkowar/yolk/compare/v0.0.9...v0.0.10) - 2024-12-09
+
+### Added
+
+- add yolk edit command
+- Add to_json and from_json lua functions
+- ensure template expressions are sandboxed
+- add contains_key, contains_value, regex_captures functions
+
+### Fixed
+
+- join lines in parser where possible
+
+### Other
+
+- fix clippy warnings
+- ensure that yolk_templates can deal with missing files
+- Document inspect.lua library
+- Add new utility functions to docs
+- document yolk safeguard and how to clone
+- simplify parser slightly
+- enable tagging in release-plz
+- Update references to replace function
+
 ## [0.0.9](https://github.com/elkowar/yolk/compare/v0.0.8...v0.0.9) - 2024-12-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "assert_fs",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.9 -> 0.0.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.10](https://github.com/elkowar/yolk/compare/v0.0.9...v0.0.10) - 2024-12-09

### Added

- add yolk edit command
- Add to_json and from_json lua functions
- ensure template expressions are sandboxed
- add contains_key, contains_value, regex_captures functions

### Fixed

- join lines in parser where possible

### Other

- fix clippy warnings
- ensure that yolk_templates can deal with missing files
- Document inspect.lua library
- Add new utility functions to docs
- document yolk safeguard and how to clone
- simplify parser slightly
- enable tagging in release-plz
- Update references to replace function
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).