### PR TITLE
Release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/elkowar/yolk/compare/v0.0.10...v0.0.11) - 2024-12-13
+
+### Added
+
+- add a few hex color utility functions
+
+### Fixed
+
+- Improve parser error message for missing end tag
+
+### Other
+
+- Use different font for docs headings to make @druskus20 happy
+- he animated now
+- Try to fix theme
+- Setup matching mdbook theme
+- *(release)* build man page as part of release process
+
 ## [0.0.10](https://github.com/elkowar/yolk/compare/v0.0.9...v0.0.10) - 2024-12-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "assert_fs",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/templating/snapshots/yolk__templating__parser__test__error_incomplete_multiline_long.snap
+++ b/src/templating/snapshots/yolk__templating__parser__test__error_incomplete_multiline_long.snap
@@ -1,0 +1,14 @@
+---
+source: src/templating/parser.rs
+expression: "render_error(parse_document(\"\\nfoo\\n{%f%}\\nbar\\n\").unwrap_err())"
+---
+  × Failed to parse yolk template file
+
+Error: 
+  × Expected end of block.
+   ╭─[file:4:4]
+ 3 │ {%f%}
+ 4 │ bar
+   ·    ┬
+   ·    ╰── here
+   ╰────

--- a/src/templating/snapshots/yolk__templating__parser__test__error_multiline_with_else.snap
+++ b/src/templating/snapshots/yolk__templating__parser__test__error_multiline_with_else.snap
@@ -1,16 +1,15 @@
 ---
 source: src/templating/parser.rs
 expression: "render_error(parse_document(\"{%f%}\\n{%else%}\\n{%end%}\").unwrap_err())"
-snapshot_kind: text
 ---
   × Failed to parse yolk template file
 
 Error: 
   × Expected valid element.
-   ╭─[file:2:3]
+   ╭─[file:1:6]
  1 │ {%f%}
- 2 │ {%else%}
-   ·   ───┬───
+   ·      ┬
    ·      ╰── here
+ 2 │ {%else%}
  3 │ {%end%}
    ╰────


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.10 -> 0.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.11](https://github.com/elkowar/yolk/compare/v0.0.10...v0.0.11) - 2024-12-13

### Added

- add a few hex color utility functions

### Fixed

- Improve parser error message for missing end tag

### Other

- Use different font for docs headings to make @druskus20 happy
- he animated now
- Try to fix theme
- Setup matching mdbook theme
- *(release)* build man page as part of release process
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).