### PR TITLE
Release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/elkowar/yolk/compare/v0.0.10...v0.0.11) - 2024-12-13
+
+### Added
+
+- Implement `yolk watch` command
+- add a few hex color utility functions
+
+### Fixed
+
+- Improve parser error message for missing end tag
+
+### Other
+
+- Try harder to make @druskus20 happy
+- Slightly clean up parser code
+- Improve error message for empty tag
+- Update cargo dist to 0.26, try to use include and build-setup for man ([#9](https://github.com/elkowar/yolk/pull/9))
+- Use different font for docs headings to make @druskus20 happy
+- he animated now
+- Try to fix theme
+- Setup matching mdbook theme
+- *(release)* build man page as part of release process
+
 ## [0.0.10](https://github.com/elkowar/yolk/compare/v0.0.9...v0.0.10) - 2024-12-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "assert_fs",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.10 -> 0.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.11](https://github.com/elkowar/yolk/compare/v0.0.10...v0.0.11) - 2024-12-13

### Added

- Implement `yolk watch` command
- add a few hex color utility functions

### Fixed

- Improve parser error message for missing end tag

### Other

- Try harder to make @druskus20 happy
- Slightly clean up parser code
- Improve error message for empty tag
- Update cargo dist to 0.26, try to use include and build-setup for man ([#9](https://github.com/elkowar/yolk/pull/9))
- Use different font for docs headings to make @druskus20 happy
- he animated now
- Try to fix theme
- Setup matching mdbook theme
- *(release)* build man page as part of release process
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).