### PR TITLE
Release v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13](https://github.com/elkowar/yolk/compare/v0.0.12...v0.0.13) - 2024-12-18
+
+### Added
+
+- [**breaking**] Add explicit deployment strategies, default to put
+- add main_file config for smarter yolk edit command
+- Add more flexible loglevel configuration
+
+### Fixed
+
+- Yolk not removing dead symlinks when deploying eggs
+
 ## [0.0.12](https://github.com/elkowar/yolk/compare/v0.0.11...v0.0.12) - 2024-12-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "assert_fs",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/script/eval_ctx.rs
+++ b/src/script/eval_ctx.rs
@@ -13,6 +13,7 @@ use super::stdlib;
 
 pub const YOLK_TEXT_NAME: &str = "YOLK_TEXT";
 
+#[derive(Debug)]
 pub struct EvalCtx {
     engine: Engine,
     scope: Scope<'static>,

--- a/src/script/rhai_error.rs
+++ b/src/script/rhai_error.rs
@@ -44,7 +44,7 @@ impl RhaiError {
             let offset_start = source_code
                 .split_inclusive('\n')
                 .take(line_nr - 1)
-                .map(|x| x.len())
+                .map(|x| dbg!(x).len())
                 .sum::<usize>();
             span = if let Some(within_line) = position.position() {
                 offset_start + within_line..offset_start + within_line + 1
@@ -61,6 +61,9 @@ impl RhaiError {
                     .count();
                 offset_start + indent..offset_end
             };
+        }
+        if span.start >= source_code.len() {
+            span = source_code.len() - 1..source_code.len();
         }
         Self::SourceError {
             span,

--- a/src/snapshots/yolk__yolk__test__syntax_error_in_yolk_rhai.snap
+++ b/src/snapshots/yolk__yolk__test__syntax_error_in_yolk_rhai.snap
@@ -1,0 +1,13 @@
+---
+source: src/yolk.rs
+expression: "yolk.prepare_eval_ctx_for_templates(crate::yolk::EvalMode::Local).map_err(|e|\ncreate_regex(r\"\\[.*.rhai:\\d+:\\d+]\").unwrap().replace(&format!(\"{:?}\", e),\n\"[no-filename-in-test]\").to_string()).unwrap_err()"
+snapshot_kind: text
+---
+  × Failed to execute yolk.rhai
+  ╰─▶ Syntax error: Expecting ')' to close the parameters list of function
+      'foo' (line 2, position 1)
+   ╭─[no-filename-in-test]
+ 1 │ fn foo(
+   ·        ┬
+   ·        ╰── here
+   ╰────

--- a/src/templating/parser.rs
+++ b/src/templating/parser.rs
@@ -383,7 +383,7 @@ impl<T: Parser<I, O, E> + Sized, I: Stream + Location, O, E> ParserExt<I, O, E> 
 
 #[cfg(test)]
 mod test {
-    use crate::util::TestResult;
+    use crate::util::{render_error, TestResult};
     use insta::assert_debug_snapshot;
     use miette::GraphicalReportHandler;
     use winnow::Parser as _;
@@ -393,15 +393,6 @@ mod test {
     };
 
     use super::{new_input, p_inline_element, p_tag_line};
-
-    fn render_error(e: impl miette::Diagnostic) -> String {
-        let mut out = String::new();
-        GraphicalReportHandler::new()
-            .with_theme(miette::GraphicalTheme::unicode_nocolor())
-            .render_report(&mut out, &e)
-            .unwrap();
-        out
-    }
 
     #[test]
     fn test_inline_tag() -> TestResult {

--- a/src/templating/test.rs
+++ b/src/templating/test.rs
@@ -42,6 +42,8 @@ pub fn eval_ctx() -> EvalCtx {
     indoc!{r#"
             /* {% if false %} */
             foo
+            /* {% elif false %} */
+            foo
             /* {% elif true %} */
             bar
             /* {% else %} */
@@ -50,6 +52,8 @@ pub fn eval_ctx() -> EvalCtx {
         "#},
     indoc!{r#"
             /* {% if false %} */
+            /*<yolk> foo*/
+            /* {% elif false %} */
             /*<yolk> foo*/
             /* {% elif true %} */
             bar

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,3 +88,15 @@ pub fn setup_and_init_test_yolk() -> miette::Result<(
     yolk.init_yolk()?;
     Ok((home, yolk, eggs))
 }
+
+#[cfg(test)]
+pub fn render_error(e: impl miette::Diagnostic) -> String {
+    use miette::GraphicalReportHandler;
+
+    let mut out = String::new();
+    GraphicalReportHandler::new()
+        .with_theme(miette::GraphicalTheme::unicode_nocolor())
+        .render_report(&mut out, &e)
+        .unwrap();
+    out
+}


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.12 -> 0.0.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.13](https://github.com/elkowar/yolk/compare/v0.0.12...v0.0.13) - 2024-12-18

### Added

- [**breaking**] Add explicit deployment strategies, default to put
- add main_file config for smarter yolk edit command
- Add more flexible loglevel configuration

### Fixed

- Yolk not removing dead symlinks when deploying eggs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).