### PR TITLE
Release v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/elkowar/yolk/compare/v0.0.14...v0.0.15) - 2024-12-22
+
+### Added
+
+- Sync to canonical mode on git pull as well
+
 ## [0.0.14](https://github.com/elkowar/yolk/compare/v0.0.13...v0.0.14) - 2024-12-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "arbitrary",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.14 -> 0.0.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.15](https://github.com/elkowar/yolk/compare/v0.0.14...v0.0.15) - 2024-12-22

### Added

- Sync to canonical mode on git pull as well
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).