### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0](https://github.com/elkowar/yolk/compare/v0.0.16...v0.1.0) - 2025-01-06
+
+### Added
+
+- Clean up stale symlinks by caching deployment targets
+- Allow for both .config and standard ~/Library/... dir on mac
+
+### Fixed
+
+- Fix windows symlink deletion again
+- simplify multi error output
+- inconsistent tests, failing symlink deletion on windows
+- compile error on windows
+
 ## [0.0.16](https://github.com/elkowar/yolk/compare/v0.0.15...v0.0.16) - 2024-12-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.0.16"
+version = "0.1.0"
 dependencies = [
  "arbitrary",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.0.16"
+version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION
## 🤖 New release
* `yolk_dots`: 0.0.16 -> 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/elkowar/yolk/compare/v0.0.16...v0.1.0) - 2025-01-06

### Added

- Clean up stale symlinks by caching deployment targets
- Allow for both .config and standard ~/Library/... dir on mac

### Fixed

- Fix windows symlink deletion again
- simplify multi error output
- inconsistent tests, failing symlink deletion on windows
- compile error on windows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).