### PR TITLE
Add `rq` and `rv` shorthands to global namespace

### DIFF
--- a/src/script/stdlib.rs
+++ b/src/script/stdlib.rs
@@ -451,7 +451,9 @@ pub fn tag_module() -> Module {
         .with_params_info(["replacement: &str", "Result<String>"])
         .in_global_namespace()
         .set_into_module(&mut module, f);
-    FuncRegistration::new("rq").set_into_module(&mut module, f);
+    FuncRegistration::new("rq")
+        .in_global_namespace()
+        .set_into_module(&mut module, f);
 
     let f = |ctx: Ncc, replacement: IStr| -> RhaiFnResult<_> {
         let text: IStr = ctx.call_fn("get_yolk_text", ())?;
@@ -492,7 +494,9 @@ pub fn tag_module() -> Module {
         .with_params_info(["replacement: &str", "Result<String>"])
         .in_global_namespace()
         .set_into_module(&mut module, f);
-    FuncRegistration::new("rv").set_into_module(&mut module, f);
+    FuncRegistration::new("rv")
+        .in_global_namespace()
+        .set_into_module(&mut module, f);
 
     module
 }


### PR DESCRIPTION
This PR allows the shorthands `rq` (`replace_quoted`) and `rv` (`replace_value`) to be used just like the other shorthands.
