### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/elkowar/yolk/compare/v0.2.0...v0.2.1) - 2025-02-02
+
+### Fixed
+
+- Fix path handling on windows when interacting with git
+- Allow accessing variables and imports in template tags
+
 ## [0.2.0](https://github.com/elkowar/yolk/compare/v0.1.0...v0.2.0) - 2025-01-26
 
 ### BREAKING

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/git_tests.rs
+++ b/src/git_tests.rs
@@ -50,10 +50,14 @@ fn test_init_works() -> TestResult {
         .assert()
         .success()
         .stdout(format!(
-            "{} --yolk-dir {} --home-dir {} git-filter\n",
-            yolk_binary_path.display(),
-            env.yolk_root().path().display(),
-            env.home.path().display(),
+            "{} --yolk-dir '{}' --home-dir '{}' git-filter\n",
+            yolk_binary_path.display().to_string().replace(r"\", r"\\"),
+            env.yolk_root()
+                .path()
+                .display()
+                .to_string()
+                .replace(r"\", r"\\"),
+            env.home.path().display().to_string().replace(r"\", r"\\"),
         ));
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,9 +160,11 @@ fn init_logging(args: &Args) {
 fn run_command(args: Args) -> Result<()> {
     let mut yolk_paths = yolk::yolk_paths::YolkPaths::from_env();
     if let Some(d) = args.yolk_dir {
+        tracing::trace!("Setting yolk dir to {}", d.display());
         yolk_paths.set_yolk_dir(d);
     }
     if let Some(d) = args.home_dir {
+        tracing::trace!("Setting home dir to {}", d.display());
         yolk_paths.set_home_dir(d);
     }
 

--- a/src/yolk_paths.rs
+++ b/src/yolk_paths.rs
@@ -58,9 +58,11 @@ impl YolkPaths {
     }
 
     pub fn set_yolk_dir(&mut self, path: PathBuf) {
+        tracing::trace!("Updating oylk-dir to {}", path.display());
         self.root_path = path;
     }
     pub fn set_home_dir(&mut self, path: PathBuf) {
+        tracing::trace!("Updating home-dir to {}", path.display());
         self.home = path
             .canonical()
             .expect("Failed to canonicalize home directory");
@@ -337,7 +339,7 @@ impl Iterator for TraverseDeployment {
 #[cfg(test)]
 mod test {
     use crate::{
-        util::test_util::{setup_and_init_test_yolk, TestResult},
+        util::{self, test_util::{setup_and_init_test_yolk, TestResult}},
         yolk_paths::{Egg, DEFAULT_YOLK_RHAI},
     };
     use assert_fs::{
@@ -396,7 +398,7 @@ mod test {
         assert!(!(egg.is_deployed()?));
         yolk.sync_egg_deployment(&egg)?;
         assert!(egg.is_deployed()?);
-        fs_err::remove_file(home.child("target"))?;
+        util::remove_symlink(home.child("target"))?;
         assert!(!(egg.is_deployed()?));
         Ok(())
     }


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/elkowar/yolk/compare/v0.2.0...v0.2.1) - 2025-02-02

### Fixed

- Fix path handling on windows when interacting with git
- Allow accessing variables and imports in template tags
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).