### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/elkowar/yolk/compare/v0.2.0...v0.2.1) - 2025-02-02
+
+### Added
+
+- Allow empty targets map in egg config
+- Add further validation of yolk.rhai
+
+### Fixed
+
+- Fix path handling on windows when interacting with git
+- Allow accessing variables and imports in template tags
+
 ## [0.2.0](https://github.com/elkowar/yolk/compare/v0.1.0...v0.2.0) - 2025-01-26
 
 ### BREAKING

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/eggs_config.rs
+++ b/src/eggs_config.rs
@@ -157,9 +157,8 @@ impl EggConfig {
         let Ok(map) = value.as_map_ref() else {
             return Err(rhai_error!("egg value must be a string or a map"));
         };
-        let targets = map
-            .get("targets")
-            .ok_or_else(|| rhai_error!("egg table must contain a 'target' key"))?;
+        let empty_map = Dynamic::from(rhai::Map::new());
+        let targets = map.get("targets").unwrap_or(&empty_map);
 
         let targets = if let Ok(targets) = targets.as_immutable_string_ref() {
             maplit::hashmap! { PathBuf::from(".") => PathBuf::from(targets.to_string()) }


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/elkowar/yolk/compare/v0.2.0...v0.2.1) - 2025-02-02

### Added

- Allow empty targets map in egg config
- Add further validation of yolk.rhai

### Fixed

- Fix path handling on windows when interacting with git
- Allow accessing variables and imports in template tags
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).