### PR TITLE
Release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/elkowar/yolk/compare/v0.2.2...v0.2.3) - 2025-02-06

### BREAKING
- Move back to `yolk git` git wrapper based solution, because git filters sadly don't quite work out for all of our needs. See #42, for example.
  To ensure your repository is compatible with the latest version of yolk, simply rerun `yolk init` once.

### Added

- Open egg specific dir and open single files in yolk edit

### Fixed
- properly handle badly behaved git-filter-client implementations.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).