### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/elkowar/yolk/compare/v0.3.2...v0.3.3) - 2025-04-25
+
+### Added
+
+- only evaluate the active block of a conditional
+
+### Fixed
+
+- Remove broken git tests
+
 ### Added
 
 - Only evaluate true branch of conditional blocks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/elkowar/yolk/compare/v0.3.2...v0.3.3) - 2025-04-25

### Added

- only evaluate the active block of a conditional

### Fixed

- Remove broken git tests

### Added

- Only evaluate true branch of conditional blocks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).