### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/elkowar/yolk/compare/v0.3.4...v0.3.5) - 2025-11-11
+
+### Added
+
+- add pre_deploy and pre_undeploy hook
+- Add yolk exec-canonical subcommand
+
+### Ci
+
+- remove homebrew temporarily
+
+### Fixed
+
+- fix documentation of eval command (fixes #65)
+
+### Ref
+
+- remove unnecessary parentheses around closure body
+
 ## [0.3.4](https://github.com/elkowar/yolk/compare/v0.3.3...v0.3.4) - 2025-05-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/elkowar/yolk/compare/v0.3.4...v0.3.5) - 2025-11-11

### Added

- add pre_deploy and pre_undeploy hook
- Add yolk exec-canonical subcommand

### Ci

- remove homebrew temporarily

### Fixed

- fix documentation of eval command (fixes #65)

### Ref

- remove unnecessary parentheses around closure body
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).