### PR TITLE
fix: Warn on unknown egg config keys and skip deploy when no targets

### DIFF
--- a/src/yolk.rs
+++ b/src/yolk.rs
@@ -183,6 +183,13 @@ impl Yolk {
             .context("Failed to expand targets config for egg")?;
 
         if egg.config().enabled && !deployed {
+            if mappings.is_empty() {
+                tracing::warn!(
+                    "Egg {} has no deployment targets; skipping deploy",
+                    egg.name()
+                );
+                return Ok(false);
+            }
             let mut deployer = Deployer::new();
             tracing::debug!("Deploying egg {}", egg.name());
 


### PR DESCRIPTION
Typos or missing `targets` could leave an egg with an empty deployment mapping while the sync logic still logged "Successfully deployed" #59 . This change prevents that confusing message while keeping config parsing forgiving.