### PR TITLE
feat(cli): Add a subcommand to generate shell completions

### DIFF
--- a/.github/workflows/patch-homebrew-formula.yml
+++ b/.github/workflows/patch-homebrew-formula.yml
@@ -1,0 +1,105 @@
+name: Patch Homebrew Formula
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  patch-homebrew-formula:
+    runs-on: ubuntu-latest
+    env:
+      TAP_REPO: elkowar/homebrew-tap
+      APP_NAME: yolk
+    steps:
+      - name: Clone Homebrew tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+          cd tap
+
+          git config user.name "cargo-dist bot"
+          git config user.email "dist@example.com"
+
+      - name: Add shell completions to formula
+        run: |
+          cd tap
+
+          if [ ! -f "$FORMULA_FILE" ]; then
+            echo "Formula file not found: $FORMULA_FILE"
+            exit 0
+          fi
+
+          python3 << 'SCRIPT'
+          import os
+          import re
+
+          app_name = os.environ['APP_NAME']
+          formula_file = os.environ['FORMULA_FILE']
+
+          with open(formula_file, "r") as f:
+            content = f.read()
+
+          # Skip if completions are already present
+          if "generate_completions_from_executable" in content:
+            print(f"Completions already present in {formula_file}")
+            exit(0)
+
+          # Find the def install block and inject completions inside it.
+          install_pattern = r'(\s+def install\b.*?)(\n\s+end\b)'
+          match = re.search(install_pattern, content, re.DOTALL)
+
+          if not match:
+            print(f"WARNING: Could not find def install block in {formula_file}")
+            exit(0)
+
+          install_block = match.group(1)
+          block_suffix = match.group(2)
+
+          # Find the last bin.install line inside the def install block
+          bin_install_matches = list(
+            re.finditer(r'\n(\s+bin\.install\s+.*?)$', install_block, re.MULTILINE)
+          )
+
+          if bin_install_matches:
+            # Inject after the last bin.install line, preserving indentation
+            last_match = bin_install_matches[-1]
+            indent_match = re.match(r'(\s*)', last_match.group(1))
+            indent = indent_match.group(1)
+            insert_point = last_match.end()
+            new_block = (
+              install_block[:insert_point]
+              + f"\n{indent}generate_completions_from_executable(bin/\"{app_name}\", shell_parameter_format: :clap)"
+              + install_block[insert_point:]
+            )
+          else:
+            print(f"WARNING: Could not find bin install in the def install block")
+            exit(0)
+
+          new_content = content[:match.start()] + new_block + block_suffix + content[match.end():]
+
+          with open(formula_file, "w") as f:
+            f.write(new_content)
+          print(f"Added completions to {formula_file}")
+          SCRIPT
+        env:
+          APP_NAME: yolk
+          FORMULA_FILE: Formula/yolk.rb
+
+      - name: Commit and push tap changes
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          cd tap
+
+          git add Formula/
+
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(homebrew): add shell completions" -m "[no-ci]"
+            git push
+          else
+            echo "No tap changes to push"
+          fi

--- a/.github/workflows/patch-homebrew-formula.yml
+++ b/.github/workflows/patch-homebrew-formula.yml
@@ -1,3 +1,8 @@
+# cargo-dist generates and publishes the Homebrew formula, but its template has no
+# support for shell completions. This post-announce job clones the tap, injects a
+# `generate_completions_from_executable(..., shell_parameter_format: :clap)` call into
+# the formula's `install` block (so Homebrew builds completions from `COMPLETE=<shell> yolk`),
+# then commits the change back to the tap.
 name: Patch Homebrew Formula
 
 on:
@@ -29,13 +34,14 @@ jobs:
           cd tap
 
           if [ ! -f "$FORMULA_FILE" ]; then
-            echo "Formula file not found: $FORMULA_FILE"
-            exit 0
+            echo "ERROR: Formula file not found: $FORMULA_FILE" >&2
+            exit 1
           fi
 
           python3 << 'SCRIPT'
           import os
           import re
+          import sys
 
           app_name = os.environ['APP_NAME']
           formula_file = os.environ['FORMULA_FILE']
@@ -46,15 +52,17 @@ jobs:
           # Skip if completions are already present
           if "generate_completions_from_executable" in content:
             print(f"Completions already present in {formula_file}")
-            exit(0)
+            sys.exit(0)
 
           # Find the def install block and inject completions inside it.
           install_pattern = r'(\s+def install\b.*?)(\n\s+end\b)'
           match = re.search(install_pattern, content, re.DOTALL)
 
           if not match:
-            print(f"WARNING: Could not find def install block in {formula_file}")
-            exit(0)
+            # Fail loudly: the formula format changed and we would otherwise
+            # silently ship a release without shell completions.
+            print(f"ERROR: Could not find def install block in {formula_file}", file=sys.stderr)
+            sys.exit(1)
 
           install_block = match.group(1)
           block_suffix = match.group(2)
@@ -76,8 +84,8 @@ jobs:
               + install_block[insert_point:]
             )
           else:
-            print(f"WARNING: Could not find bin install in the def install block")
-            exit(0)
+            print(f"ERROR: Could not find bin install in the def install block", file=sys.stderr)
+            sys.exit(1)
 
           new_content = content[:match.start()] + new_block + block_suffix + content[match.end():]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -64,9 +64,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -120,7 +120,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -135,7 +135,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -149,7 +149,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
@@ -166,7 +166,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -183,19 +183,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -213,7 +213,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -243,19 +243,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -268,14 +268,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -308,14 +308,14 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: true
           repository: "elkowar/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: Formula/
@@ -355,7 +355,16 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
+
+  custom-patch-homebrew-formula:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/patch-homebrew-formula.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2152,7 @@ dependencies = [
  "assert_fs",
  "cached",
  "clap",
+ "clap_complete",
  "cov-mark",
  "dirs",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -234,7 +234,7 @@ checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.4",
  "strsim",
 ]
 
@@ -245,6 +245,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
 dependencies = [
  "clap",
+ "clap_lex 1.0.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -264,6 +267,12 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -651,7 +660,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -829,6 +838,15 @@ name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1505,6 +1523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,12 +2056,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2046,7 +2076,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2055,14 +2094,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2072,10 +2128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2084,10 +2152,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2096,10 +2176,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2108,10 +2200,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ symlink = "0.1.0"
 hex = "0.4.3"
 walkdir = "2.5.0"
 tracing-tree = "0.4.0"
+clap_complete = "4.5.66"
 # rhai-autodocs = { version = "0.7.0", path = "../../clones/rhai-autodocs" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ notify-debouncer-full = "0.5.0"
 owo-colors = { version = "4.1.0", features = ["supports-colors"] }
 regex = "1.11.1"
 rhai = { version = "1.21.0", features = [
-    "std",
-    "internals",
-    "no_custom_syntax",
-    "sync",
+  "std",
+  "internals",
+  "no_custom_syntax",
+  "sync",
 ], default-features = false }
 tracing = "0.1.41"
 rhai-autodocs = { version = "0.8.0", optional = true }
@@ -54,7 +54,7 @@ symlink = "0.1.0"
 hex = "0.4.3"
 walkdir = "2.5.0"
 tracing-tree = "0.4.0"
-clap_complete = "4.5.66"
+clap_complete = { version = "4.5.66", features = ["unstable-dynamic"] }
 # rhai-autodocs = { version = "0.7.0", path = "../../clones/rhai-autodocs" }
 
 [dev-dependencies]
@@ -63,14 +63,14 @@ rstest = { version = "0.24.0", default-features = false }
 # tracing-tree = "0.4.0"
 assert_fs = "1.1.2"
 insta = { version = "1.42.1", default-features = false, features = [
-    "colors",
-    "redactions",
-    "filters",
+  "colors",
+  "redactions",
+  "filters",
 ] }
 predicates = "3.1.3"
 test-log = { version = "0.2.17", default-features = false, features = [
-    "color",
-    "trace",
+  "color",
+  "trace",
 ] }
 assert_cmd = "2.0.16"
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ github-attestations = true
 # Global artifacts jobs to run in CI
 global-artifacts-jobs = ["./build-man"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.2"
+cargo-dist-version = "0.32.0"
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # CI backends to support
@@ -31,6 +31,8 @@ install-updater = false
 tap = "elkowar/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
+# Post-announce jobs: patch Homebrew formula after publishing
+post-announce-jobs = ["./patch-homebrew-formula"]
 
 [dist.github-custom-runners]
 # Use an `ubuntu-latest` runner for all "global" steps of the release process,

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -54,6 +54,11 @@ and for `powershell` run
 echo '$env:COMPLETE = "powershell"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\COMPLETE' >> $PROFILE
 ```
 
+Static completions may also be generated using
+```sh
+yolk shell-completions <SHELL>
+```
+
 ### Adding your first egg
 
 let's say we want to manage the configuration for the `alacritty` terminal emulator.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -30,16 +30,29 @@ $ yolk init
 
 This will create the yolk directory, with a default `yolk.rhai` file, and an `eggs` directory.
 
-If you installed `yolk` with cargo some other manual method, you may want to generate shell completions.
-```fish
-$ yolk shell-completions fish > ~/.config/fish/completions/yolk.fish
+### Shell completions
+
+`yolk` comes with built-in shell completions for `bash`, `zsh`, `fish`, `elvish` and `powershell`.
+To enable those, for `bash` run
+```bash
+echo "source <(COMPLETE=bash yolk)" >> ~/.bashrc
 ```
-For `bash` the user completions by default live in `${XDG_DATA_HOME}/bash-completion/completions/` and for `zsh` they
-live in the `$fpath`.
-If you are not sure, see the completion documentation for
-[`bash`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html) or
-[`zsh`](https://zsh.sourceforge.io/Doc/Release/Completion-System.html) or the documentation for the framework that you
-are using for configuration (e.g. Oh My Zsh).
+for `zsh`, run
+```zsh
+echo "source <(COMPLETE=zsh yolk)" >> ~/.zshrc
+```
+for `fish` run
+```fish
+echo "COMPLETE=fish yolk | source" >> ~/.config/fish/completions/yolk.fish
+```
+for `elvish` run
+```elvish
+echo "eval (E:COMPLETE=elvish yolk | slurp)" >> ~/.elvish/rc.elv
+```
+and for `powershell` run
+```powershell
+echo '$env:COMPLETE = "powershell"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\COMPLETE' >> $PROFILE
+```
 
 ### Adding your first egg
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -30,6 +30,17 @@ $ yolk init
 
 This will create the yolk directory, with a default `yolk.rhai` file, and an `eggs` directory.
 
+If you installed `yolk` with cargo some other manual method, you may want to generate shell completions.
+```fish
+$ yolk shell-completions fish > ~/.config/fish/completions/yolk.fish
+```
+For `bash` the user completions by default live in `${XDG_DATA_HOME}/bash-completion/completions/` and for `zsh` they
+live in the `$fpath`.
+If you are not sure, see the completion documentation for
+[`bash`](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html) or
+[`zsh`](https://zsh.sourceforge.io/Doc/Release/Completion-System.html) or the documentation for the framework that you
+are using for configuration (e.g. Oh My Zsh).
+
 ### Adding your first egg
 
 let's say we want to manage the configuration for the `alacritty` terminal emulator.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -30,35 +30,6 @@ $ yolk init
 
 This will create the yolk directory, with a default `yolk.rhai` file, and an `eggs` directory.
 
-### Shell completions
-
-`yolk` comes with built-in shell completions for `bash`, `zsh`, `fish`, `elvish` and `powershell`.
-To enable those, for `bash` run
-```bash
-echo "source <(COMPLETE=bash yolk)" >> ~/.bashrc
-```
-for `zsh`, run
-```zsh
-echo "source <(COMPLETE=zsh yolk)" >> ~/.zshrc
-```
-for `fish` run
-```fish
-echo "COMPLETE=fish yolk | source" >> ~/.config/fish/completions/yolk.fish
-```
-for `elvish` run
-```elvish
-echo "eval (E:COMPLETE=elvish yolk | slurp)" >> ~/.elvish/rc.elv
-```
-and for `powershell` run
-```powershell
-echo '$env:COMPLETE = "powershell"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\COMPLETE' >> $PROFILE
-```
-
-Static completions may also be generated using
-```sh
-yolk shell-completions <SHELL>
-```
-
 ### Adding your first egg
 
 let's say we want to manage the configuration for the `alacritty` terminal emulator.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -41,6 +41,11 @@ for `zsh`, run
 ```zsh
 echo "source <(COMPLETE=zsh yolk)" >> ~/.zshrc
 ```
+Note that zsh's completion system must be initialized before this line runs. If your `~/.zshrc`
+doesn't already do so (frameworks like oh-my-zsh do it for you), add the following *above* it:
+```zsh
+autoload -Uz compinit && compinit
+```
 for `fish` run
 ```fish
 echo "COMPLETE=fish yolk | source" >> ~/.config/fish/completions/yolk.fish

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -30,6 +30,30 @@ $ yolk init
 
 This will create the yolk directory, with a default `yolk.rhai` file, and an `eggs` directory.
 
+### Shell completions
+
+`yolk` comes with built-in shell completions for `bash`, `zsh`, `fish`, `elvish` and `powershell`.
+To enable those, for `bash` run
+```bash
+echo "source <(COMPLETE=bash yolk)" >> ~/.bashrc
+```
+for `zsh`, run
+```zsh
+echo "source <(COMPLETE=zsh yolk)" >> ~/.zshrc
+```
+for `fish` run
+```fish
+echo "COMPLETE=fish yolk | source" >> ~/.config/fish/completions/yolk.fish
+```
+for `elvish` run
+```elvish
+echo "eval (E:COMPLETE=elvish yolk | slurp)" >> ~/.elvish/rc.elv
+```
+and for `powershell` run
+```powershell
+echo '$env:COMPLETE = "powershell"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\COMPLETE' >> $PROFILE
+```
+
 ### Adding your first egg
 
 let's say we want to manage the configuration for the `alacritty` terminal emulator.

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ enum Command {
     /// Run a given shell command within a canonical context. I.e.: `yolk exec-canonical gitui`.
     #[clap(name = "exec-canonical")]
     ExecCanonical {
-        #[clap(allow_hyphen_values = true)]
+        #[clap(allow_hyphen_values = true, last=true, value_hint=ValueHint::CommandWithArguments)]
         command: Vec<String>,
     },
     /// Evaluate a Rhai expression.
@@ -96,6 +96,7 @@ enum Command {
         canonical: bool,
         /// The path to the file you want to evaluate
         /// If not provided, the program will read from stdin
+        #[arg(value_hint=ValueHint::FilePath)]
         path: Option<PathBuf>,
     },
 
@@ -117,7 +118,9 @@ enum Command {
     /// Run a git-command within the yolk directory.
     #[clap(alias = "g")]
     Git {
-        #[clap(allow_hyphen_values = true)]
+        // TODO: Test whether the command is being completed (works only in bash currently).
+        // Possibly would need to pre-fill with the `git` command  <kunzaatko, 16-02-2026>
+        #[clap(allow_hyphen_values = true, last=true, value_hint=ValueHint::CommandWithArguments)]
         command: Vec<String>,
         /// Force yolk to run the command with canonicalized files, regardless of what command it is.
         #[arg(long)]
@@ -132,13 +135,16 @@ enum Command {
     RootManageSymlinks {
         #[arg(long, value_names = ["ORIGINAL::::SYMLINK_PATH"], required = false, value_parser=parse_symlink_pair)]
         create_symlink: Vec<(PathBuf, PathBuf)>,
-        #[arg(long, value_names = ["SYMLINK_PATH"], required = false)]
+        #[arg(long, value_names = ["SYMLINK_PATH"], required = false, value_hint=ValueHint::AnyPath)]
         delete_symlink: Vec<PathBuf>,
     },
 
     #[cfg(feature = "docgen")]
     #[command(hide(true))]
-    Docs { dir: PathBuf },
+    Docs {
+        #[arg(value_hint=ValueHint::DirPath)]
+        dir: PathBuf,
+    },
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use std::{
     str::FromStr,
 };
 
-use clap::{CommandFactory, Parser, Subcommand};
-use clap_complete::env::CompleteEnv;
+use clap::{CommandFactory, Parser, Subcommand, ValueHint};
+use clap_complete::{env::CompleteEnv, generate, Shell};
 use fs_err::PathExt as _;
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
@@ -123,6 +123,10 @@ enum Command {
         #[arg(long)]
         force_canonical: bool,
     },
+
+    /// Generate shell completions
+    #[command(hide(true))]
+    ShellCompletions { shell: Option<Shell> },
 
     #[command(hide(true))]
     RootManageSymlinks {
@@ -255,6 +259,18 @@ fn run_command(args: Args) -> Result<()> {
                     })
                 });
                 println!("{}", text);
+            }
+        }
+        Command::ShellCompletions { shell } => {
+            if let Some(shell) = shell {
+                generate(*shell, &mut Args::command(), "yolk", &mut std::io::stdout());
+            } else {
+                generate(
+                    Shell::from_env().unwrap_or(Shell::Bash),
+                    &mut Args::command(),
+                    "yolk",
+                    &mut std::io::stdout(),
+                );
             }
         }
         Command::Sync { canonical } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::{builder::StyledStr, CommandFactory, Parser, Subcommand, ValueHint};
-use clap_complete::{env::CompleteEnv, generate, ArgValueCompleter, CompletionCandidate, Shell};
+use clap_complete::{env::CompleteEnv, ArgValueCompleter, CompletionCandidate, Shell};
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use owo_colors::OwoColorize as _;
@@ -131,7 +131,10 @@ enum Command {
 
     /// Generate shell completions
     #[command(hide(true))]
-    ShellCompletions { shell: Option<Shell> },
+    ShellCompletions {
+        #[arg(long)]
+        shell: Option<Shell>,
+    },
 
     #[command(hide(true))]
     RootManageSymlinks {
@@ -175,6 +178,28 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
             completion
         })
         .collect::<Vec<CompletionCandidate>>()
+}
+
+fn print_shell_competions(shell: &Shell) -> Result<()> {
+    match shell {
+        Shell::Fish => {
+            println!("COMPLETE=fish yolk | source");
+        }
+        Shell::Bash => {
+            println!("source <(COMPLETE=bash yolk)");
+        }
+        Shell::Elvish => {
+            println!("eval (E:COMPLETE=elvish yolk | slurp)")
+        }
+        Shell::Zsh => {
+            println!("source <(COMPLETE=zsh yolk)")
+        }
+        Shell::PowerShell => {
+            println!("$env:COMPLETE = \"powershell\"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\\COMPLETE");
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {
@@ -299,14 +324,9 @@ fn run_command(args: Args) -> Result<()> {
         }
         Command::ShellCompletions { shell } => {
             if let Some(shell) = shell {
-                generate(*shell, &mut Args::command(), "yolk", &mut std::io::stdout());
+                print_shell_competions(shell)?
             } else {
-                generate(
-                    Shell::from_env().unwrap_or(Shell::Bash),
-                    &mut Args::command(),
-                    "yolk",
-                    &mut std::io::stdout(),
-                );
+                print_shell_competions(&Shell::from_env().unwrap_or(Shell::Bash))?;
             }
         }
         Command::Sync { canonical } => {
@@ -483,7 +503,7 @@ fn run_command(args: Args) -> Result<()> {
                                     eprintln!("Error: {e:?}");
                                 }
                             } else {
-                                changed.iter().for_each(|path| on_file_updated(&path));
+                                changed.iter().for_each(|path| on_file_updated(path));
                             }
                         }
                         Err(error) => tracing::error!("Error: {error:?}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,14 +396,10 @@ fn run_command(args: Args) -> Result<()> {
                 Some(egg_name) => {
                     let egg = yolk.load_egg(egg_name)?;
                     let main_file = egg.edit_path()?;
-                    let cd_path = egg
-                        .find_first_deployed_symlink()?
-                        .unwrap_or_else(|| yolk.paths().egg_path(egg.name()));
+                    let cd_path = egg.edit_dir()?;
                     let _ = std::env::set_current_dir(&cd_path);
                     if let Some(ref main_file) = main_file {
-                        edit::edit_file(egg.path().join(main_file)).into_diagnostic()?;
-                    } else {
-                        edit::edit_file(&cd_path).into_diagnostic()?;
+                        edit::edit_file(main_file).into_diagnostic()?;
                     }
                 }
                 None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use std::{
 
 use clap::{builder::StyledStr, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{env::CompleteEnv, generate, ArgValueCompleter, CompletionCandidate, Shell};
-use fs_err::PathExt as _;
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use owo_colors::OwoColorize as _;
@@ -22,7 +21,7 @@ use yolk::{
     deploy::Deployer,
     util::PathExt as _,
     yolk::{EvalMode, Yolk},
-    yolk_paths::{self, Egg},
+    yolk_paths,
 };
 
 #[derive(clap::Parser, Debug)]
@@ -170,30 +169,12 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         .filter(|(_, name)| name.starts_with(current))
         .map(|(egg, name)| {
             let mut completion = CompletionCandidate::new(name);
-            if let Ok(Some(path)) = edit_path(&yolk, egg) {
+            if let Ok(Some(path)) = egg.edit_path() {
                 completion = completion.help(Some(StyledStr::from(path.display().to_string())))
             }
             completion
         })
         .collect::<Vec<CompletionCandidate>>()
-}
-
-fn edit_path(yolk: &Yolk, egg: &Egg) -> Result<Option<PathBuf>> {
-    let cd_path = egg
-        .find_first_deployed_symlink()?
-        .unwrap_or_else(|| yolk.paths().egg_path(egg.name()));
-    let _ = std::env::set_current_dir(&cd_path);
-    let mut main_file = egg.config().main_file.clone();
-    // If no main_file is specified and there's exactly one file in the egg directory, use that
-    if main_file.is_none() {
-        let mut files = egg.path().fs_err_read_dir().into_diagnostic()?;
-        if let Some(first_file) = files.next() {
-            if files.next().is_none() {
-                main_file = Some(first_file.into_diagnostic()?.path());
-            }
-        }
-    }
-    Ok(main_file)
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {
@@ -414,10 +395,11 @@ fn run_command(args: Args) -> Result<()> {
             match egg_name {
                 Some(egg_name) => {
                     let egg = yolk.load_egg(egg_name)?;
-                    let main_file = edit_path(&yolk, &egg)?;
+                    let main_file = egg.edit_path()?;
                     let cd_path = egg
                         .find_first_deployed_symlink()?
                         .unwrap_or_else(|| yolk.paths().egg_path(egg.name()));
+                    let _ = std::env::set_current_dir(&cd_path);
                     if let Some(ref main_file) = main_file {
                         edit::edit_file(egg.path().join(main_file)).into_diagnostic()?;
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::{CommandFactory, Parser, Subcommand, ValueHint};
-use clap_complete::{env::CompleteEnv, generate, Shell};
+use clap_complete::{env::CompleteEnv, generate, ArgValueCompleter, CompletionCandidate, Shell};
 use fs_err::PathExt as _;
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
@@ -104,7 +104,10 @@ enum Command {
     List,
 
     /// Open your `yolk.rhai` or the given egg in your `$EDITOR` of choice.
-    Edit { egg: Option<String> },
+    Edit {
+        #[arg(add = ArgValueCompleter::new(egg_completer))]
+        egg: Option<String>,
+    },
 
     /// Watch for changes in your templated files and re-sync them when they change.
     Watch {
@@ -145,6 +148,28 @@ enum Command {
         #[arg(value_hint=ValueHint::DirPath)]
         dir: PathBuf,
     },
+}
+
+fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
+    let Some(current) = current.to_str() else {
+        return vec![];
+    };
+
+    let yolk_dir = yolk_paths::default_yolk_dir();
+    let Some(home_dir) = dirs::home_dir() else {
+        return vec![];
+    };
+    let yolk_paths = yolk::yolk_paths::YolkPaths::new(yolk_dir, home_dir);
+    let yolk = Yolk::new(yolk_paths);
+
+    let Ok(eggs) = yolk.list_eggs() else {
+        return vec![];
+    };
+    eggs.iter()
+        .map(|egg| egg.name().to_string())
+        .filter(|name| name.starts_with(current))
+        .map(CompletionCandidate::new)
+        .collect::<Vec<CompletionCandidate>>()
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-use clap::{CommandFactory, Parser, Subcommand, ValueHint};
+use clap::{builder::StyledStr, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{env::CompleteEnv, generate, ArgValueCompleter, CompletionCandidate, Shell};
 use fs_err::PathExt as _;
 use miette::{Context as _, IntoDiagnostic, Result};
@@ -22,7 +22,7 @@ use yolk::{
     deploy::Deployer,
     util::PathExt as _,
     yolk::{EvalMode, Yolk},
-    yolk_paths,
+    yolk_paths::{self, Egg},
 };
 
 #[derive(clap::Parser, Debug)]
@@ -166,10 +166,34 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         return vec![];
     };
     eggs.iter()
-        .map(|egg| egg.name().to_string())
-        .filter(|name| name.starts_with(current))
-        .map(CompletionCandidate::new)
+        .map(|egg| (egg, egg.name().to_string()))
+        .filter(|(_, name)| name.starts_with(current))
+        .map(|(egg, name)| {
+            let mut completion = CompletionCandidate::new(name);
+            if let Ok(Some(path)) = edit_path(&yolk, egg) {
+                completion = completion.help(Some(StyledStr::from(path.display().to_string())))
+            }
+            completion
+        })
         .collect::<Vec<CompletionCandidate>>()
+}
+
+fn edit_path(yolk: &Yolk, egg: &Egg) -> Result<Option<PathBuf>> {
+    let cd_path = egg
+        .find_first_deployed_symlink()?
+        .unwrap_or_else(|| yolk.paths().egg_path(egg.name()));
+    let _ = std::env::set_current_dir(&cd_path);
+    let mut main_file = egg.config().main_file.clone();
+    // If no main_file is specified and there's exactly one file in the egg directory, use that
+    if main_file.is_none() {
+        let mut files = egg.path().fs_err_read_dir().into_diagnostic()?;
+        if let Some(first_file) = files.next() {
+            if files.next().is_none() {
+                main_file = Some(first_file.into_diagnostic()?.path());
+            }
+        }
+    }
+    Ok(main_file)
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {
@@ -390,20 +414,10 @@ fn run_command(args: Args) -> Result<()> {
             match egg_name {
                 Some(egg_name) => {
                     let egg = yolk.load_egg(egg_name)?;
+                    let main_file = edit_path(&yolk, &egg)?;
                     let cd_path = egg
                         .find_first_deployed_symlink()?
-                        .unwrap_or_else(|| yolk.paths().egg_path(egg_name));
-                    let _ = std::env::set_current_dir(&cd_path);
-                    let mut main_file = egg.config().main_file.clone();
-                    // If no main_file is specified and there's exactly one file in the egg directory, use that
-                    if main_file.is_none() {
-                        let mut files = egg.path().fs_err_read_dir().into_diagnostic()?;
-                        if let Some(first_file) = files.next() {
-                            if files.next().is_none() {
-                                main_file = Some(first_file.into_diagnostic()?.path());
-                            }
-                        }
-                    }
+                        .unwrap_or_else(|| yolk.paths().egg_path(egg.name()));
                     if let Some(ref main_file) = main_file {
                         edit::edit_file(egg.path().join(main_file)).into_diagnostic()?;
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::{builder::StyledStr, CommandFactory, Parser, Subcommand, ValueHint};
-use clap_complete::{env::CompleteEnv, ArgValueCompleter, CompletionCandidate, Shell};
+use clap_complete::{env::CompleteEnv, ArgValueCompleter, CompletionCandidate};
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use owo_colors::OwoColorize as _;
@@ -129,13 +129,6 @@ enum Command {
         force_canonical: bool,
     },
 
-    /// Generate shell completions
-    #[command(hide(true))]
-    ShellCompletions {
-        #[arg(long)]
-        shell: Option<Shell>,
-    },
-
     #[command(hide(true))]
     RootManageSymlinks {
         #[arg(long, value_names = ["ORIGINAL::::SYMLINK_PATH"], required = false, value_parser=parse_symlink_pair)]
@@ -178,28 +171,6 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
             completion
         })
         .collect::<Vec<CompletionCandidate>>()
-}
-
-fn print_shell_competions(shell: &Shell) -> Result<()> {
-    match shell {
-        Shell::Fish => {
-            println!("COMPLETE=fish yolk | source");
-        }
-        Shell::Bash => {
-            println!("source <(COMPLETE=bash yolk)");
-        }
-        Shell::Elvish => {
-            println!("eval (E:COMPLETE=elvish yolk | slurp)")
-        }
-        Shell::Zsh => {
-            println!("source <(COMPLETE=zsh yolk)")
-        }
-        Shell::PowerShell => {
-            println!("$env:COMPLETE = \"powershell\"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\\COMPLETE");
-        }
-        _ => unreachable!(),
-    }
-    Ok(())
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {
@@ -320,13 +291,6 @@ fn run_command(args: Args) -> Result<()> {
                     })
                 });
                 println!("{}", text);
-            }
-        }
-        Command::ShellCompletions { shell } => {
-            if let Some(shell) = shell {
-                print_shell_competions(shell)?
-            } else {
-                print_shell_competions(&Shell::from_env().unwrap_or(Shell::Bash))?;
             }
         }
         Command::Sync { canonical } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::{builder::StyledStr, CommandFactory, Parser, Subcommand, ValueHint};
-use clap_complete::{env::CompleteEnv, generate, ArgValueCompleter, CompletionCandidate, Shell};
+use clap_complete::{env::CompleteEnv, ArgValueCompleter, CompletionCandidate, Shell};
 use miette::{Context as _, IntoDiagnostic, Result};
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode, DebounceEventResult};
 use owo_colors::OwoColorize as _;
@@ -131,7 +131,10 @@ enum Command {
 
     /// Generate shell completions
     #[command(hide(true))]
-    ShellCompletions { shell: Option<Shell> },
+    ShellCompletions {
+        #[arg(long)]
+        shell: Option<Shell>,
+    },
 
     #[command(hide(true))]
     RootManageSymlinks {
@@ -175,6 +178,28 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
             completion
         })
         .collect::<Vec<CompletionCandidate>>()
+}
+
+fn print_shell_competions(shell: &Shell) -> Result<()> {
+    match shell {
+        Shell::Fish => {
+            println!("COMPLETE=fish yolk | source");
+        }
+        Shell::Bash => {
+            println!("source <(COMPLETE=bash yolk)");
+        }
+        Shell::Elvish => {
+            println!("eval (E:COMPLETE=elvish yolk | slurp)")
+        }
+        Shell::Zsh => {
+            println!("source <(COMPLETE=zsh yolk)")
+        }
+        Shell::PowerShell => {
+            println!("$env:COMPLETE = \"powershell\"; yolk | Out-String | Invoke-Expression; Remove-Item Env:\\COMPLETE");
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
 }
 
 fn parse_symlink_pair(s: &str) -> Result<(PathBuf, PathBuf), String> {
@@ -299,14 +324,9 @@ fn run_command(args: Args) -> Result<()> {
         }
         Command::ShellCompletions { shell } => {
             if let Some(shell) = shell {
-                generate(*shell, &mut Args::command(), "yolk", &mut std::io::stdout());
+                print_shell_competions(shell)?
             } else {
-                generate(
-                    Shell::from_env().unwrap_or(Shell::Bash),
-                    &mut Args::command(),
-                    "yolk",
-                    &mut std::io::stdout(),
-                );
+                print_shell_competions(&Shell::from_env().unwrap_or(Shell::Bash))?;
             }
         }
         Command::Sync { canonical } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,11 +150,20 @@ fn egg_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
         return vec![];
     };
 
-    let yolk_dir = yolk_paths::default_yolk_dir();
-    let Some(home_dir) = dirs::home_dir() else {
+    // Completion runs before arg parsing, so the `--yolk-dir`/`--home-dir` flags
+    // aren't available here. We still honor their environment variable equivalents.
+    let yolk_dir = std::env::var_os("YOLK_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(yolk_paths::default_yolk_dir);
+    let Some(home_dir) = std::env::var_os("YOLK_HOME_DIR")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+    else {
         return vec![];
     };
-    let yolk_paths = yolk::yolk_paths::YolkPaths::new(yolk_dir, home_dir);
+    let Ok(yolk_paths) = yolk::yolk_paths::YolkPaths::new(yolk_dir, home_dir) else {
+        return vec![];
+    };
     let yolk = Yolk::new(yolk_paths);
 
     let Ok(eggs) = yolk.list_eggs() else {
@@ -255,7 +264,7 @@ fn run_command(args: Args) -> Result<()> {
         .wrap_err("No home dir could be found")?;
     tracing::trace!("Setting yolk dir to {}", yolk_dir.display());
     tracing::trace!("Setting home dir to {}", home_dir.display());
-    let yolk_paths = yolk::yolk_paths::YolkPaths::new(yolk_dir, home_dir);
+    let yolk_paths = yolk::yolk_paths::YolkPaths::new(yolk_dir, home_dir)?;
 
     let yolk = Yolk::new(yolk_paths);
     match &args.command {

--- a/src/util.rs
+++ b/src/util.rs
@@ -218,7 +218,7 @@ pub mod test_util {
         use assert_fs::prelude::PathChild as _;
 
         let home = assert_fs::TempDir::new().into_diagnostic()?;
-        let paths = crate::yolk_paths::YolkPaths::new(home.join("yolk"), home.to_path_buf());
+        let paths = crate::yolk_paths::YolkPaths::new(home.join("yolk"), home.to_path_buf())?;
         let yolk = crate::yolk::Yolk::new(paths);
         std::env::set_var("HOME", "/tmp/TEST_HOMEDIR_SHOULD_NOT_BE_USED");
         set_home_dir(home.to_path_buf());

--- a/src/yolk_paths.rs
+++ b/src/yolk_paths.rs
@@ -266,19 +266,33 @@ impl Egg {
         &self.egg_dir
     }
 
-    /// Path to the main file of the egg
+    /// Edit directory of the Egg
+    pub fn edit_dir(&self) -> Result<PathBuf> {
+        Ok(self
+            .find_first_deployed_symlink()?
+            .unwrap_or_else(|| self.path().into()))
+    }
+
+    /// Path to the main file of the Egg
     pub fn edit_path(&self) -> Result<Option<PathBuf>> {
-        let mut main_file = self.config().main_file.clone();
+        let mut edit_path = self
+            .config()
+            .main_file
+            .clone()
+            .map(|file| self.path().join(file));
         // If no main_file is specified and there's exactly one file in the egg directory, use that
-        if main_file.is_none() {
+        if edit_path.is_none() {
             let mut files = self.path().fs_err_read_dir().into_diagnostic()?;
             if let Some(first_file) = files.next() {
                 if files.next().is_none() {
-                    main_file = Some(first_file.into_diagnostic()?.path());
+                    edit_path = Some(first_file.into_diagnostic()?.path());
                 }
             }
         }
-        Ok(main_file)
+        if edit_path.is_none() {
+            edit_path = Some(self.edit_dir()?);
+        }
+        Ok(edit_path)
     }
 
     /// Check if the egg is _fully_ deployed (-> All contained entries have corresponding symlinks)

--- a/src/yolk_paths.rs
+++ b/src/yolk_paths.rs
@@ -266,6 +266,21 @@ impl Egg {
         &self.egg_dir
     }
 
+    /// Path to the main file of the egg
+    pub fn edit_path(&self) -> Result<Option<PathBuf>> {
+        let mut main_file = self.config().main_file.clone();
+        // If no main_file is specified and there's exactly one file in the egg directory, use that
+        if main_file.is_none() {
+            let mut files = self.path().fs_err_read_dir().into_diagnostic()?;
+            if let Some(first_file) = files.next() {
+                if files.next().is_none() {
+                    main_file = Some(first_file.into_diagnostic()?.path());
+                }
+            }
+        }
+        Ok(main_file)
+    }
+
     /// Check if the egg is _fully_ deployed (-> All contained entries have corresponding symlinks)
     #[tracing::instrument(skip_all, fields(egg.name = %self.name()))]
     pub fn is_deployed(&self) -> Result<bool> {

--- a/src/yolk_paths.rs
+++ b/src/yolk_paths.rs
@@ -48,13 +48,13 @@ pub fn default_yolk_dir() -> PathBuf {
 }
 
 impl YolkPaths {
-    pub fn new(path: PathBuf, home: PathBuf) -> Self {
-        YolkPaths {
+    pub fn new(path: PathBuf, home: PathBuf) -> Result<Self> {
+        Ok(YolkPaths {
             root_path: path,
             home: home
                 .canonical()
-                .expect("Failed to canonicalize home directory"),
-        }
+                .wrap_err("Failed to canonicalize home directory")?,
+        })
     }
 
     pub fn set_yolk_dir(&mut self, path: PathBuf) {
@@ -440,7 +440,8 @@ mod test {
     #[test]
     pub fn test_setup() {
         let root = assert_fs::TempDir::new().unwrap();
-        let yolk_paths = YolkPaths::new(root.child("yolk").to_path_buf(), root.to_path_buf());
+        let yolk_paths =
+            YolkPaths::new(root.child("yolk").to_path_buf(), root.to_path_buf()).unwrap();
         assert!(yolk_paths.check().is_err());
         yolk_paths.create().unwrap();
         assert!(yolk_paths.check().is_ok());
@@ -519,7 +520,7 @@ mod test {
     #[test]
     pub fn test_default_script() -> TestResult {
         let root = TempDir::new().into_diagnostic()?;
-        let yolk_paths = YolkPaths::new(root.child("yolk").to_path_buf(), root.to_path_buf());
+        let yolk_paths = YolkPaths::new(root.child("yolk").to_path_buf(), root.to_path_buf())?;
         yolk_paths.create().unwrap();
         let yolk = crate::yolk::Yolk::new(yolk_paths);
         _ = yolk.prepare_eval_ctx_for_templates(crate::yolk::EvalMode::Local)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -41,7 +41,7 @@ struct TestEnv {
 impl TestEnv {
     pub fn init() -> TestResult<Self> {
         let home = assert_fs::TempDir::new()?;
-        let paths = YolkPaths::new(home.join("yolk"), home.to_path_buf());
+        let paths = YolkPaths::new(home.join("yolk"), home.to_path_buf())?;
         let yolk = Yolk::new(paths);
         // Ensure neither the in-process library nor the spawned binary touch the
         // real home directory. The binary is additionally given `--home-dir`


### PR DESCRIPTION
Adds a subcommand to generate shell completions using `clap_complete`.
It is quite straight forward.

![demo](https://github.com/user-attachments/assets/973080aa-1571-44b4-bf42-2bce3a65266d)

Next steps: 
- [x] Add a note to the docs for the feature under the CLI section
- [x] Add completion generation to the build scripts or generate in CI/CD and commit if changed as an asset (@elkowar
  what is your preference here?)
  - Commands for completion are now in the docs. They could be in the homebrew formula for the shells that allow
    a completion directory or they could be better advertised in the installation documentation...
- [x] Add some hints for the subcommands such as `yolk edit ...` should complete the eggs
- [ ] `yolk git ...` should complete `git` commands under the `yolk` directory (This is currently not possible for
  native completions and would have to be deferred until the support lands).
- [x] Hide the hidden subcommand that is shown in the completions but is hidden from the _help_ section
