### PR TITLE
feat: Add shell fallback feature for hooks

### DIFF
--- a/docs/src/yolk_rhai.md
+++ b/docs/src/yolk_rhai.md
@@ -58,6 +58,14 @@ export let eggs = #{
             pre_undeploy: "yet another shellscript",
         }
     }
+
+    # Example with fallback hook - runs fallback if primary command fails
+    fragile_egg: #{
+        targets: "~/fragile",
+        unsafe_shell_hooks: #{
+            pre_deploy: #{ shell: "check_prereq", fallback: "echo 'Prereq failed, continuing anyway'" },
+        }
+    }
 }
 ```
 
@@ -97,8 +105,31 @@ Files that are not listed here will not be edited by yolk during `yolk sync`!
 A path, relative to the egg directory, that will be opened when you run `yolk edit <eggname>`.
 
 #### `unsafe_shell_hooks`
-An object that may declare two scripts, which get ran when the egg is deployed or un-deployed.
+An object that may declare scripts, which get ran when the egg is deployed or un-deployed.
 The `pre_deploy` script gets executed before the egg is deployed, the `pre_undeploy` script gets executed before the egg is un-deployed, the `post_deploy` script gets executed after the egg has been deployed, the `post_undeploy` script gets executed after the egg has been un-deployed.
+
+Each hook can be defined in two ways:
+
+**Simple syntax** - just a string:
+```rhai
+unsafe_shell_hooks: #{
+    pre_deploy: "some shellscript",
+}
+```
+
+**With fallback** - a map with `shell` and optional `fallback`:
+```rhai
+unsafe_shell_hooks: #{
+    pre_deploy: #{ shell: "primary_command", fallback: "fallback_command" },
+    post_deploy: #{ shell: "touch ~/.deployed", fallback: "echo 'Post-deploy failed'" },
+}
+```
+
+When using fallback syntax:
+1. The primary `shell` command is executed first
+2. If the primary command fails (non-zero exit), the `fallback` command is executed
+3. If the fallback also fails, the hook fails with an error
+4. If no fallback is defined and the primary command fails, the hook fails with an error
 
 Note that these scripts should optimally be idempodent, so running them twice should not change anything compared to running them once.
 

--- a/src/eggs_config.rs
+++ b/src/eggs_config.rs
@@ -44,42 +44,65 @@ impl FromStr for DeploymentStrategy {
     }
 }
 
+/// A shell hook that can optionally have a fallback command to run if the primary fails.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HookWithFallback {
+    pub shell: String,
+    pub fallback: Option<String>,
+}
+
+impl HookWithFallback {
+    pub fn new(shell: impl Into<String>) -> Self {
+        Self {
+            shell: shell.into(),
+            fallback: None,
+        }
+    }
+
+    pub fn with_fallback(mut self, fallback: impl Into<String>) -> Self {
+        self.fallback = Some(fallback.into());
+        self
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ShellHooks {
-    pub post_deploy: Option<String>,
-    pub post_undeploy: Option<String>,
-    pub pre_deploy: Option<String>,
-    pub pre_undeploy: Option<String>,
-    // pub post_sync: Option<String>,
+    pub post_deploy: Option<HookWithFallback>,
+    pub post_undeploy: Option<HookWithFallback>,
+    pub pre_deploy: Option<HookWithFallback>,
+    pub pre_undeploy: Option<HookWithFallback>,
+    // pub post_sync: Option<HookWithFallback>,
 }
 
 impl ShellHooks {
     pub fn run_post_deploy(&self) -> miette::Result<()> {
-        if let Some(command) = &self.post_deploy {
-            tracing::debug!("Running post-deploy script");
-            run_hook(command)?;
+        if let Some(hook) = &self.post_deploy {
+            tracing::debug!("Running post-deploy hook");
+            run_hook(hook)?;
         }
         Ok(())
     }
 
     pub fn run_post_undeploy(&self) -> miette::Result<()> {
-        if let Some(command) = &self.post_undeploy {
-            tracing::debug!("Running post-undeploy script");
-            run_hook(command)?;
+        if let Some(hook) = &self.post_undeploy {
+            tracing::debug!("Running post-undeploy hook");
+            run_hook(hook)?;
         }
         Ok(())
     }
+
     pub fn run_pre_deploy(&self) -> miette::Result<()> {
-        if let Some(command) = &self.pre_deploy {
-            tracing::debug!("Running pre-deploy script");
-            run_hook(command)?;
+        if let Some(hook) = &self.pre_deploy {
+            tracing::debug!("Running pre-deploy hook");
+            run_hook(hook)?;
         }
         Ok(())
     }
+
     pub fn run_pre_undeploy(&self) -> miette::Result<()> {
-        if let Some(command) = &self.pre_undeploy {
-            tracing::debug!("Running pre-undeploy script");
-            run_hook(command)?;
+        if let Some(hook) = &self.pre_undeploy {
+            tracing::debug!("Running pre-undeploy hook");
+            run_hook(hook)?;
         }
         Ok(())
     }
@@ -93,18 +116,35 @@ impl ShellHooks {
     // }
 }
 
-fn run_hook(command: &str) -> miette::Result<()> {
+fn run_hook(hook: &HookWithFallback) -> miette::Result<()> {
     let status = Command::new("sh")
         .arg("-c")
-        .arg(command)
+        .arg(&hook.shell)
         .status()
-        .map_err(|e| miette::miette!("Failed to run post-deploy hook: {}", e))?;
+        .map_err(|e| miette::miette!("Failed to run hook: {}", e))?;
 
     if !status.success() {
-        miette::bail!(
-            "Post-deploy hook failed with status {}",
-            status.code().unwrap_or(-1)
-        );
+        if let Some(fallback) = &hook.fallback {
+            tracing::debug!(
+                "Primary command failed (status {}), running fallback: {}",
+                status.code().unwrap_or(-1),
+                fallback
+            );
+            let fallback_status = Command::new("sh")
+                .arg("-c")
+                .arg(fallback)
+                .status()
+                .map_err(|e| miette::miette!("Failed to run fallback hook: {}", e))?;
+
+            if !fallback_status.success() {
+                miette::bail!(
+                    "Fallback hook also failed with status {}",
+                    fallback_status.code().unwrap_or(-1)
+                );
+            }
+        } else {
+            miette::bail!("Hook failed with status {}", status.code().unwrap_or(-1));
+        }
     }
     Ok(())
 }
@@ -181,6 +221,34 @@ impl Default for EggConfig {
             },
         }
     }
+}
+
+
+/// Parse a shell hook from a dynamic value.
+/// Supports both simple string syntax and map syntax with fallback:
+///   - Simple: `pre_deploy: "ls"`
+///   - With fallback: `pre_deploy: #{ shell: "ls", fallback: "echo 'fail'" }`
+fn parse_shell_hook(value: &rhai::Dynamic) -> Option<HookWithFallback> {
+    // Support simple string syntax
+    if let Ok(s) = value.as_immutable_string_ref() {
+        return Some(HookWithFallback::new(s.to_string()));
+    }
+
+    // Support map syntax with shell and optional fallback
+    if let Ok(map) = value.as_map_ref() {
+        let shell = map.get("shell")?.as_immutable_string_ref().ok()?;
+        let fallback = map
+            .get("fallback")
+            .and_then(|v| v.as_immutable_string_ref().ok())
+            .map(|s| s.to_string());
+
+        return Some(HookWithFallback {
+            shell: shell.to_string(),
+            fallback,
+        });
+    }
+
+    None
 }
 
 impl EggConfig {
@@ -368,10 +436,10 @@ impl EggConfig {
                 }
             }
             ShellHooks {
-                post_deploy: shell_hooks.get("post_deploy").map(|v| v.to_string()),
-                post_undeploy: shell_hooks.get("post_undeploy").map(|v| v.to_string()),
-                pre_deploy: shell_hooks.get("pre_deploy").map(|v| v.to_string()),
-                pre_undeploy: shell_hooks.get("pre_undeploy").map(|v| v.to_string()),
+                post_deploy: shell_hooks.get("post_deploy").map(parse_shell_hook).flatten(),
+                post_undeploy: shell_hooks.get("post_undeploy").map(parse_shell_hook).flatten(),
+                pre_deploy: shell_hooks.get("pre_deploy").map(parse_shell_hook).flatten(),
+                pre_undeploy: shell_hooks.get("pre_undeploy").map(parse_shell_hook).flatten(),
             }
         } else {
             ShellHooks::default()
@@ -401,7 +469,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        eggs_config::{DeploymentStrategy, EggConfig, ShellHooks},
+        eggs_config::{DeploymentStrategy, EggConfig, HookWithFallback, ShellHooks},
         util::test_util::TestResult,
     };
 
@@ -429,10 +497,10 @@ mod test {
             .with_strategy(DeploymentStrategy::Merge)
             .with_main_file("foo")
             .with_unsafe_hooks(ShellHooks {
-                post_deploy: Some("run after deploy".to_string()),
-                post_undeploy: Some("run after undeploy".to_string()),
-                pre_deploy: Some("run before deploy".to_string()),
-                pre_undeploy: Some("run before undeploy".to_string()),
+                post_deploy: Some(HookWithFallback::new("run after deploy")),
+                post_undeploy: Some(HookWithFallback::new("run after undeploy")),
+                pre_deploy: Some(HookWithFallback::new("run before deploy")),
+                pre_undeploy: Some(HookWithFallback::new("run before undeploy")),
             })
     )]
     #[case(r#"#{ targets: "~/bar" }"#, EggConfig::new(".", "~/bar"))]

--- a/src/eggs_config.rs
+++ b/src/eggs_config.rs
@@ -78,7 +78,7 @@ impl ShellHooks {
     pub fn run_post_deploy(&self) -> miette::Result<()> {
         if let Some(hook) = &self.post_deploy {
             tracing::debug!("Running post-deploy hook");
-            run_hook(hook)?;
+            run_hook_for_test(hook)?;
         }
         Ok(())
     }
@@ -86,7 +86,7 @@ impl ShellHooks {
     pub fn run_post_undeploy(&self) -> miette::Result<()> {
         if let Some(hook) = &self.post_undeploy {
             tracing::debug!("Running post-undeploy hook");
-            run_hook(hook)?;
+            run_hook_for_test(hook)?;
         }
         Ok(())
     }
@@ -94,7 +94,7 @@ impl ShellHooks {
     pub fn run_pre_deploy(&self) -> miette::Result<()> {
         if let Some(hook) = &self.pre_deploy {
             tracing::debug!("Running pre-deploy hook");
-            run_hook(hook)?;
+            run_hook_for_test(hook)?;
         }
         Ok(())
     }
@@ -102,7 +102,7 @@ impl ShellHooks {
     pub fn run_pre_undeploy(&self) -> miette::Result<()> {
         if let Some(hook) = &self.pre_undeploy {
             tracing::debug!("Running pre-undeploy hook");
-            run_hook(hook)?;
+            run_hook_for_test(hook)?;
         }
         Ok(())
     }
@@ -116,7 +116,7 @@ impl ShellHooks {
     // }
 }
 
-fn run_hook(hook: &HookWithFallback) -> miette::Result<()> {
+pub fn run_hook_for_test(hook: &HookWithFallback) -> miette::Result<()> {
     let status = Command::new("sh")
         .arg("-c")
         .arg(&hook.shell)
@@ -503,6 +503,36 @@ mod test {
                 pre_undeploy: Some(HookWithFallback::new("run before undeploy")),
             })
     )]
+    #[case(
+        indoc::indoc! {r#"
+            #{
+                targets: "~/bar",
+                unsafe_shell_hooks: #{
+                    pre_deploy: #{ shell: "check_prereq", fallback: "echo 'fallback'" },
+                }
+            }
+        "#},
+        EggConfig::new(".", "~/bar")
+            .with_unsafe_hooks(ShellHooks {
+                pre_deploy: Some(HookWithFallback::new("check_prereq").with_fallback("echo 'fallback'")),
+                ..Default::default()
+            })
+    )]
+    #[case(
+        indoc::indoc! {r#"
+            #{
+                targets: "~/bar",
+                unsafe_shell_hooks: #{
+                    post_deploy: #{ shell: "primary_cmd" },
+                }
+            }
+        "#},
+        EggConfig::new(".", "~/bar")
+            .with_unsafe_hooks(ShellHooks {
+                post_deploy: Some(HookWithFallback::new("primary_cmd")),
+                ..Default::default()
+            })
+    )]
     #[case(r#"#{ targets: "~/bar" }"#, EggConfig::new(".", "~/bar"))]
     #[case(r#""~/bar""#, EggConfig::new(".", "~/bar"))]
     fn test_read_eggs_config(#[case] input: &str, #[case] expected: EggConfig) -> TestResult {
@@ -564,5 +594,53 @@ mod test {
         );
         let cfg = parsed.unwrap();
         assert_eq!(cfg.unsafe_shell_hooks, ShellHooks::default());
+    }
+
+    #[test]
+    fn test_hook_with_fallback_parsing() {
+        // Test parsing of HookWithFallback with builder pattern
+        let hook = HookWithFallback::new("primary").with_fallback("fallback");
+        assert_eq!(hook.shell, "primary");
+        assert_eq!(hook.fallback, Some("fallback".to_string()));
+
+        // Test parsing without fallback
+        let hook_no_fallback = HookWithFallback::new("primary");
+        assert_eq!(hook_no_fallback.shell, "primary");
+        assert_eq!(hook_no_fallback.fallback, None);
+    }
+
+    #[test]
+    fn test_hook_with_fallback_default() {
+        let hook = HookWithFallback::default();
+        assert_eq!(hook.shell, "");
+        assert_eq!(hook.fallback, None);
+    }
+
+    #[test]
+    fn test_run_hook_success() {
+        let hook = HookWithFallback::new("echo 'success'");
+        let result = crate::eggs_config::run_hook_for_test(&hook);
+        assert!(result.is_ok(), "Hook should succeed with exit code 0");
+    }
+
+    #[test]
+    fn test_run_hook_failure_without_fallback() {
+        let hook = HookWithFallback::new("exit 1");
+        let result = crate::eggs_config::run_hook_for_test(&hook);
+        assert!(result.is_err(), "Hook should fail without fallback");
+    }
+
+    #[test]
+    fn test_run_hook_failure_with_successful_fallback() {
+        let hook = HookWithFallback::new("exit 1").with_fallback("echo 'fallback ran'");
+        let result = crate::eggs_config::run_hook_for_test(&hook);
+        assert!(result.is_ok(), "Hook should succeed when fallback succeeds: {:?}", result);
+    }
+
+    #[test]
+    fn test_run_hook_failure_with_failing_fallback() {
+        let hook = HookWithFallback::new("exit 1").with_fallback("exit 2");
+        let result = crate::eggs_config::run_hook_for_test(&hook);
+        assert!(result.is_err(), "Hook should fail when both primary and fallback fail");
     }
 }

--- a/src/tests/yolk_tests.rs
+++ b/src/tests/yolk_tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::{
-    eggs_config::{DeploymentStrategy, ShellHooks},
+    eggs_config::{DeploymentStrategy, HookWithFallback, ShellHooks},
     util::test_util::{setup_and_init_test_yolk, TestResult},
     yolk::EvalMode,
     yolk_paths::Egg,
@@ -53,16 +53,16 @@ fn test_egg_post_deploy_hooks() -> TestResult {
         .with_strategy(DeploymentStrategy::Put)
         .with_target("foo.toml", home.child("foo.toml"))
         .with_unsafe_hooks(ShellHooks {
-            post_deploy: Some(format!("touch {}/post_deploy_ran", home.display())),
-            post_undeploy: Some(format!("touch {}/post_undeploy_ran", home.display())),
-            pre_deploy: Some(format!("touch {}/pre_deploy_ran", home.display())),
-            pre_undeploy: Some(format!("touch {}/pre_undeploy_ran", home.display())),
+            post_deploy: Some(HookWithFallback::new(format!("touch {}/post_deploy_ran", home.display()))),
+            post_undeploy: Some(HookWithFallback::new(format!("touch {}/post_undeploy_ran", home.display()))),
+            pre_deploy: Some(HookWithFallback::new(format!("touch {}/pre_deploy_ran", home.display()))),
+            pre_undeploy: Some(HookWithFallback::new(format!("touch {}/pre_undeploy_ran", home.display()))),
         });
     let egg_again = egg.clone().with_unsafe_hooks(ShellHooks {
-        post_deploy: Some(format!("touch {}/post_deploy_ran_again", home.display())),
-        post_undeploy: Some(format!("touch {}/post_undeploy_ran_again", home.display())),
-        pre_deploy: Some(format!("touch {}/pre_deploy_ran_again", home.display())),
-        pre_undeploy: Some(format!("touch {}/pre_undeploy_ran_again", home.display())),
+        post_deploy: Some(HookWithFallback::new(format!("touch {}/post_deploy_ran_again", home.display()))),
+        post_undeploy: Some(HookWithFallback::new(format!("touch {}/post_undeploy_ran_again", home.display()))),
+        pre_deploy: Some(HookWithFallback::new(format!("touch {}/pre_deploy_ran_again", home.display()))),
+        pre_undeploy: Some(HookWithFallback::new(format!("touch {}/pre_undeploy_ran_again", home.display()))),
     });
     yolk.sync_egg_deployment(&Egg::open(
         home.to_path_buf(),


### PR DESCRIPTION
## Summary

This PR adds a **shell fallback feature** for hooks in the yolk configuration. When a hook's primary command fails, an optional fallback command can now run automatically.

## Changes

### New Struct: HookWithFallback
- `shell`: The primary shell command to execute
- `fallback`: Optional fallback command if primary fails

### Updated ShellHooks
All hook fields now use `Option<HookWithFallback>`:
- `pre_deploy`
- `post_deploy`
- `pre_undeploy`
- `post_undeploy`

## Config Syntax

**Simple (no fallback):**
```
unsafe_shell_hooks: #{
    pre_deploy: "check_prereq",
}
```

**With fallback:**
```
unsafe_shell_hooks: #{
    pre_deploy: #{ shell: "check_prereq", fallback: "echo fallback" },
}
```

## Behavior
1. Run primary command
2. If **success** → done
3. If **failure** and fallback exists → run fallback
   - If fallback **success** → done
   - If fallback **fails** → error
4. If **failure** and no fallback → error

## Tests Added
- Parsing tests for both syntaxes
- Unit tests for `HookWithFallback` struct
- Runtime tests for all execution scenarios (success, failure without fallback, failure with successful fallback, failure with failing fallback)

## Documentation
Updated `yolk_rhai.md` with new syntax examples and behavior explanation.
