### PR TITLE
Release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/elkowar/yolk/compare/v0.3.7...v0.3.8) - 2026-05-19
+
+### Fixed
+
+- Also pin mdbook-man mdbook version to 0.4
+
 ## [0.3.7](https://github.com/elkowar/yolk/compare/v0.3.6...v0.3.7) - 2026-05-19
 
 ### Ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.3.7 -> 0.3.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/elkowar/yolk/compare/v0.3.7...v0.3.8) - 2026-05-19

### Fixed

- Also pin mdbook-man mdbook version to 0.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).