### PR TITLE
Release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/elkowar/yolk/compare/v0.3.8...v0.3.9) - 2026-07-05
+
+### Added
+
+- add `ignore` tag for literal/raw template regions
+- *(cli)* add native shell completions ([#74](https://github.com/elkowar/yolk/pull/74)) ([#74](https://github.com/elkowar/yolk/issues/74) [#74](https://github.com/elkowar/yolk/issues/74) )
+
+### Fixed
+
+- locate test binary via integration test to survive build-dir changes
+- clippy warnings
+
+### Fmt
+
+- format parser
+
 ## [0.3.8](https://github.com/elkowar/yolk/compare/v0.3.7...v0.3.8) - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 0.3.8 -> 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.9](https://github.com/elkowar/yolk/compare/v0.3.8...v0.3.9) - 2026-07-05

### Added

- add `ignore` tag for literal/raw template regions
- *(cli)* add native shell completions ([#74](https://github.com/elkowar/yolk/pull/74)) ([#74](https://github.com/elkowar/yolk/issues/74) [#74](https://github.com/elkowar/yolk/issues/74) )

### Fixed

- locate test binary via integration test to survive build-dir changes
- clippy warnings

### Fmt

- format parser
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).