### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/elkowar/yolk/compare/v1.0.0...v1.1.0) - 2026-07-06
+
+### Added
+
+- add support for aarch64-linux-android, enabling termux support (fixes #81)
+
+### Chore
+
+- fix title on oranda page
+- release v1.0.0 ([#84](https://github.com/elkowar/yolk/pull/84))
+
 ## [1.0.0](https://github.com/elkowar/yolk/compare/v0.3.9...v1.0.0) - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/elkowar/yolk/compare/v1.0.0...v1.1.0) - 2026-07-06

### Added

- add support for aarch64-linux-android, enabling termux support (fixes #81)

### Chore

- fix title on oranda page
- release v1.0.0 ([#84](https://github.com/elkowar/yolk/pull/84))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).