### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,21 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add adopt command that moves config into egg dir and prints config
 - improved parser diagnostics
 
-### Chore
-
-- release as 1.0.0
-- clean up docs and lint issues
 
 ### Fixed
 
 - correctness fixes for adopt, stale symlink cleanup, and parser keywords
 - several small correctness risks regarding sync
 - improve symlink escalation flow
-
-### Refactor
-
-- simple unified test harness making tests more semantically meaningful
-- rework parser structure
 
 ## [0.3.9](https://github.com/elkowar/yolk/compare/v0.3.8...v0.3.9) - 2026-07-05
 
@@ -52,15 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - locate test binary via integration test to survive build-dir changes
-- clippy warnings
-
-### Fmt
-
-- format parser
 
 ## [0.3.8](https://github.com/elkowar/yolk/compare/v0.3.7...v0.3.8) - 2026-05-19
 
-### Fixed
+### Ci
 
 - Also pin mdbook-man mdbook version to 0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/elkowar/yolk/compare/v1.1.0...v1.1.1) - 2026-07-06
+
+### Chore
+
+- cleanup changelog
+
 ## [1.1.0](https://github.com/elkowar/yolk/compare/v1.0.0...v1.1.0) - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 1.1.0 -> 1.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/elkowar/yolk/compare/v1.1.0...v1.1.1) - 2026-07-06

### Chore

- cleanup changelog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).