### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/elkowar/yolk/compare/v1.1.0...v1.2.0) - 2026-07-09
+
+### Added
+
+- improve rhai function-not-found errors by showing altenate, existing signatures
+
+### Chore
+
+- cleanup changelog
+
+### Docs
+
+- update rhai stdlib
+
+### Fixed
+
+- fix double-printing some function not found errors
+
+### Refactor
+
+- Error handling improvements and nicer error printing
+
 ## [1.1.0](https://github.com/elkowar/yolk/compare/v1.0.0...v1.1.0) - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"

--- a/src/script/rhai_error.rs
+++ b/src/script/rhai_error.rs
@@ -10,7 +10,6 @@ pub enum RhaiScriptError {
     Located {
         #[label("here")]
         span: SourceSpan,
-        #[diagnostic_source]
         kind: RhaiScriptErrorKind,
     },
     #[error(transparent)]
@@ -160,4 +159,51 @@ fn clamp_span(span: SourceSpan, source_len: usize) -> SourceSpan {
     let requested_len = span.len();
     let len = requested_len.min(source_len.saturating_sub(start));
     (start, len).into()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::script::eval_ctx::EvalCtx;
+    use crate::util::test_util::render_report;
+    use crate::yolk::EvalMode;
+
+    /// Evaluate a rhai snippet that is expected to fail, and render the
+    /// resulting error report exactly as a user would see it on the CLI.
+    fn render_rhai_error(source: &str) -> String {
+        let mut ctx = EvalCtx::new_in_mode(EvalMode::Local).unwrap();
+        let err = ctx
+            .eval_rhai::<()>(source)
+            .expect_err("expected rhai evaluation to fail");
+        render_report(err.into_report("<inline>", source))
+    }
+
+    #[test]
+    fn test_enriched_unknown_function_renders_once() {
+        insta::assert_snapshot!(render_rhai_error(r#"ptint("hi")"#));
+    }
+
+    #[test]
+    fn test_enriched_wrong_arguments_renders_once() {
+        insta::assert_snapshot!(render_rhai_error("io::path_exists(1)"));
+    }
+
+    #[test]
+    fn test_generic_runtime_error() {
+        insta::assert_snapshot!(render_rhai_error("1 / 0"));
+    }
+
+    #[test]
+    fn test_nested_function_call_error() {
+        insta::assert_snapshot!(render_rhai_error("fn boom() { 1 / 0 } boom()"));
+    }
+
+    #[test]
+    fn test_variable_not_found() {
+        insta::assert_snapshot!(render_rhai_error("foo + 1"));
+    }
+
+    #[test]
+    fn test_syntax_error() {
+        insta::assert_snapshot!(render_rhai_error("let x = "));
+    }
 }

--- a/src/script/snapshots/yolk__script__rhai_error__test__enriched_unknown_function_renders_once.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__enriched_unknown_function_renders_once.snap
@@ -1,0 +1,11 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(r#\"ptint(\"hi\")\"#)"
+---
+  × Unknown function `ptint`. Did you mean `print`?
+   ╭─[<inline>:1:2]
+ 1 │ ptint("hi")
+   ·  ┬
+   ·  ╰── here
+   ╰────
+  help: Similar functions: `print`

--- a/src/script/snapshots/yolk__script__rhai_error__test__enriched_wrong_arguments_renders_once.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__enriched_wrong_arguments_renders_once.snap
@@ -1,0 +1,12 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(\"io::path_exists(1)\")"
+---
+  × Function `io::path_exists` exists, but no overload accepts arguments: i64
+   ╭─[<inline>:1:6]
+ 1 │ io::path_exists(1)
+   ·      ┬
+   ·      ╰── here
+   ╰────
+  help: Available overloads:
+          - io::path_exists(p: string) -> Result<bool>

--- a/src/script/snapshots/yolk__script__rhai_error__test__generic_runtime_error.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__generic_runtime_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(\"1 / 0\")"
+---
+  × Division by zero: 1 / 0
+   ╭─[<inline>:1:1]
+ 1 │ 1 / 0
+   · ▲
+   · ╰── here
+   ╰────

--- a/src/script/snapshots/yolk__script__rhai_error__test__nested_function_call_error.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__nested_function_call_error.snap
@@ -1,0 +1,11 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(\"fn boom() { 1 / 0 } boom()\")"
+---
+  × Division by zero: 1 / 0
+  │ in call to function 'boom' (line 1, position 21)
+   ╭─[<inline>:1:22]
+ 1 │ fn boom() { 1 / 0 } boom()
+   ·                      ┬
+   ·                      ╰── here
+   ╰────

--- a/src/script/snapshots/yolk__script__rhai_error__test__syntax_error.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__syntax_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(\"let x = \")"
+---
+  × Syntax error: Script is incomplete (line 1, position 9)
+   ╭─[<inline>:1:8]
+ 1 │ let x = 
+   ·        ┬
+   ·        ╰── here
+   ╰────

--- a/src/script/snapshots/yolk__script__rhai_error__test__variable_not_found.snap
+++ b/src/script/snapshots/yolk__script__rhai_error__test__variable_not_found.snap
@@ -1,0 +1,10 @@
+---
+source: src/script/rhai_error.rs
+expression: "render_rhai_error(\"foo + 1\")"
+---
+  × Variable not found: foo (line 1, position 1)
+   ╭─[<inline>:1:2]
+ 1 │ foo + 1
+   ·  ┬
+   ·  ╰── here
+   ╰────

--- a/src/templating/error.rs
+++ b/src/templating/error.rs
@@ -14,8 +14,14 @@ pub enum TemplateError {
     #[error("{error}")]
     #[diagnostic(forward(error))]
     Rhai {
-        #[source]
-        #[diagnostic_source]
+        // NOTE: `error` is intentionally neither `#[source]` nor
+        // `#[diagnostic_source]`. Its `Display` is already forwarded as this
+        // variant's message (`#[error("{error}")]`), so exposing it as a cause
+        // would make the graphical handler print the message twice — and the
+        // nested render would reuse the inner, expression-local span, planting
+        // the "here" label at the wrong offset in the template source. We only
+        // forward the diagnostic metadata (help, code, ...) and attach our own
+        // template-relative label via `error_span`.
         error: RhaiScriptError,
         #[label(primary, "here")]
         error_span: Option<SourceSpan>,

--- a/src/tests/snapshots/yolk__tests__yolk_tests__template_runtime_error_rendering.snap
+++ b/src/tests/snapshots/yolk__tests__yolk_tests__template_runtime_error_rendering.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/yolk_tests.rs
+expression: "env.yolk().eval_template(&mut eval_ctx, \"template.conf\",\n\"before\\nvalue = {< 1 / 0 >}\\nafter\\n\",).map_err(test_util::render_report).unwrap_err()"
+---
+  × Failed to render document `template.conf`
+  ╰─▶ Failed to evaluate template
+  ╰─▶   × Division by zero: 1 / 0
+         ╭─[template.conf:2:12]
+       1 │ before
+       2 │ value = {< 1 / 0 >}
+         ·            ▲
+         ·            ╰── here
+       3 │ after
+         ╰────

--- a/src/tests/snapshots/yolk__tests__yolk_tests__template_unknown_function_error_rendering.snap
+++ b/src/tests/snapshots/yolk__tests__yolk_tests__template_unknown_function_error_rendering.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/yolk_tests.rs
+expression: "env.yolk().eval_template(&mut eval_ctx, \"template.conf\",\n\"before\\nvalue = {< ptint(\\\"hi\\\") >}\\nafter\\n\",).map_err(test_util::render_report).unwrap_err()"
+---
+  × Failed to render document `template.conf`
+  ╰─▶ Failed to evaluate template
+  ╰─▶   × Unknown function `ptint`. Did you mean `print`?
+         ╭─[template.conf:2:13]
+       1 │ before
+       2 │ value = {< ptint("hi") >}
+         ·             ┬
+         ·             ╰── here
+       3 │ after
+         ╰────
+        help: Similar functions: `print`

--- a/src/tests/yolk_tests.rs
+++ b/src/tests/yolk_tests.rs
@@ -636,6 +636,48 @@ pub fn test_rhai_function_hint_keeps_template_span() -> TestResult {
     Ok(())
 }
 
+/// An enriched rhai error inside a template tag must render once, with the
+/// label pointing into the template source (not the isolated expression).
+#[test]
+#[cfg(not(windows))]
+pub fn test_template_unknown_function_error_rendering() -> TestResult {
+    let env = TestEnv::init()?;
+    let mut eval_ctx = env
+        .yolk()
+        .prepare_eval_ctx_for_templates(EvalMode::Local)?;
+    insta::assert_snapshot!(env
+        .yolk()
+        .eval_template(
+            &mut eval_ctx,
+            "template.conf",
+            "before\nvalue = {< ptint(\"hi\") >}\nafter\n",
+        )
+        .map_err(test_util::render_report)
+        .unwrap_err());
+    Ok(())
+}
+
+/// A plain runtime error inside a template tag renders once with the template
+/// span highlighted.
+#[test]
+#[cfg(not(windows))]
+pub fn test_template_runtime_error_rendering() -> TestResult {
+    let env = TestEnv::init()?;
+    let mut eval_ctx = env
+        .yolk()
+        .prepare_eval_ctx_for_templates(EvalMode::Local)?;
+    insta::assert_snapshot!(env
+        .yolk()
+        .eval_template(
+            &mut eval_ctx,
+            "template.conf",
+            "before\nvalue = {< 1 / 0 >}\nafter\n",
+        )
+        .map_err(test_util::render_report)
+        .unwrap_err());
+    Ok(())
+}
+
 #[test]
 #[cfg(not(windows))]
 pub fn test_deployment_error() -> TestResult {


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 1.1.0 -> 1.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0](https://github.com/elkowar/yolk/compare/v1.1.0...v1.2.0) - 2026-07-09

### Added

- improve rhai function-not-found errors by showing altenate, existing signatures

### Chore

- cleanup changelog

### Docs

- update rhai stdlib

### Fixed

- fix double-printing some function not found errors

### Refactor

- Error handling improvements and nicer error printing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).