### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/elkowar/yolk/compare/v1.2.0...v1.2.1) - 2026-07-09
+
+### Ci
+
+- update release-plz config
+- fix broken build-setup.yml
+
 ## [1.2.0](https://github.com/elkowar/yolk/compare/v1.1.0...v1.2.0) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yolk_dots"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "arbitrary",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yolk_dots"
 authors = ["ElKowar <dev@elkowar.dev>"]
 description = "Templated dotfile management without template files"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 repository = "https://github.com/elkowar/yolk"
 homepage = "https://elkowar.github.io/yolk"


### PR DESCRIPTION



## 🤖 New release

* `yolk_dots`: 1.2.0 -> 1.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.1](https://github.com/elkowar/yolk/compare/v1.2.0...v1.2.1) - 2026-07-09

### Ci

- update release-plz config
- fix broken build-setup.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).